### PR TITLE
Compiler warning due to extraneous semicolon

### DIFF
--- a/NSTimer+Blocks.m
+++ b/NSTimer+Blocks.m
@@ -25,7 +25,7 @@
     return ret;
 }
 
-+(void)jdExecuteSimpleBlock:(NSTimer *)inTimer;
++(void)jdExecuteSimpleBlock:(NSTimer *)inTimer
 {
     if([inTimer userInfo])
     {


### PR DESCRIPTION
A semicolon following a method signature in `@implementation` triggers this compiler warning:

```
warning: semicolon before method body is ignored [-Wsemicolon-before-method-body]
```

`-Wsemicolon-before-method-body` is implied by `-Wall -Wextra`, the preferred compiler flags of anal-retentive freaks.
